### PR TITLE
added library definition for platformIO & increment version number in library.properties

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,21 @@
+{
+  "name": "nRF905 Radio Library",
+  "version": "4.0.1",
+  "keywords": "Arduino, Communication, nRF905, Nordic, 433Mhz, 868Mhz, 915Mhz, STM32, ESP8266, NodeMCU, ESP32, M5Stack",
+  "description": "nRF905 Radio Library for Arduino",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/zkemble/nRF905-arduino"
+  },
+  "authors":
+  [
+    {
+        "name": "Zak Kemble",
+        "email": "contact@zakkemble.net",
+        "maintainer": true
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "*"
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=nRF905 Radio Library
-version=4.0.0
+version=4.0.1
 author=Zak Kemble <contact@zakkemble.net>
 maintainer=Zak Kemble <contact@zakkemble.net>
 sentence=nRF905 Radio Library for Arduino


### PR DESCRIPTION
The library.json allows platformIO to reference the library as a dependency within the platform.ini allowing easy and seamless integration and automatic updates  