### PR TITLE
ESP Arduino framework fix

### DIFF
--- a/examples/debug/debug.ino
+++ b/examples/debug/debug.ino
@@ -14,7 +14,13 @@
 #include <nRF905_defs.h>
 #include <SPI.h>
 
-nRF905 transceiver = nRF905();
+// Provide SPI bus to use (SPI, SPI1, SPI2 etc)
+nRF905 transceiver = nRF905(SPI);
+
+// NOTE: If you want to use another SPI bus on an ESP (which uses the VSPI bus by default) - you can initiate the library like this:
+// Also don't forget to uncomment the above initialization line!
+// SPIClass dSPI(HSPI);
+// nRF905 transceiver = nRF905(dSPI);
 
 // Don't modify these 2 functions. They just pass the DR/AM interrupt to the correct nRF905 instance.
 void nRF905_int_dr(){transceiver.interrupt_dr();}
@@ -24,10 +30,7 @@ void setup()
 {
 	Serial.begin(115200);
 
-	SPI.begin();
-
 	transceiver.begin(
-		SPI, // SPI bus to use (SPI, SPI1, SPI2 etc)
 		10000000, // SPI Clock speed (10MHz)
 		6, // SPI SS
 		7, // CE (standby)

--- a/examples/lowpwr_node_baseStation/lowpwr_node_baseStation.ino
+++ b/examples/lowpwr_node_baseStation/lowpwr_node_baseStation.ino
@@ -34,7 +34,8 @@
 #define PACKET_OK		1
 #define PACKET_INVALID	2
 
-nRF905 transceiver = nRF905();
+// Provide SPI bus to use (SPI, SPI1, SPI2 etc)
+nRF905 transceiver = nRF905(SPI);
 
 static volatile uint8_t packetStatus; // NOTE: In interrupt mode this must be volatile
 
@@ -69,12 +70,8 @@ void setup()
 	//digitalWrite(9, LOW);
 	
 	
-	// This must be called first
-	SPI.begin();
-
 	// Minimal wires (interrupt mode)
 	transceiver.begin(
-		SPI,
 		10000000,
 		6,
 		NRF905_PIN_UNUSED, // CE (standby) pin must be connected to VCC (3.3V)

--- a/examples/lowpwr_node_sensor/lowpwr_node_sensor.ino
+++ b/examples/lowpwr_node_sensor/lowpwr_node_sensor.ino
@@ -27,7 +27,8 @@
 #define NODE_ID				78
 #define LED					A5
 
-nRF905 transceiver = nRF905();
+// Provide SPI bus to use (SPI, SPI1, SPI2 etc)
+nRF905 transceiver = nRF905(SPI);
 
 static bool txDone; // NOTE: In polling mode this does not need to be volatile
 
@@ -56,14 +57,10 @@ void setup()
 	//digitalWrite(9, HIGH);
 	
 	
-	// This must be called first
-	SPI.begin();
-
 	// Minimal wires (polling mode)
 	// Up to 5 wires can be disconnected, however this will reduce functionalliy and will put the library into polling mode instead of interrupt mode.
 	// In polling mode the .poll() method must be called as often as possible. If .poll() is not called often enough then events may be missed.
 	transceiver.begin(
-		SPI,
 		10000000,
 		6,
 		NRF905_PIN_UNUSED, // CE (standby) pin must be connected to VCC (3.3V)

--- a/examples/ping_client/ping_client.ino
+++ b/examples/ping_client/ping_client.ino
@@ -26,7 +26,8 @@
 #define LED				A5
 #define PAYLOAD_SIZE	NRF905_MAX_PAYLOAD // 32
 
-nRF905 transceiver = nRF905();
+// Provide SPI bus to use (SPI, SPI1, SPI2 etc)
+nRF905 transceiver = nRF905(SPI);
 
 static volatile uint8_t packetStatus;
 
@@ -60,12 +61,8 @@ void setup()
 	//pinMode(7, OUTPUT);
 	//digitalWrite(7, HIGH);
 	
-	// This must be called first
-	SPI.begin();
-
 	// All wires, maximum functionality
 	transceiver.begin(
-		SPI, // SPI bus to use (SPI, SPI1, SPI2 etc)
 		10000000, // SPI Clock speed (10MHz)
 		6, // SPI SS
 		7, // CE (standby)

--- a/examples/ping_server/ping_server.ino
+++ b/examples/ping_server/ping_server.ino
@@ -23,7 +23,8 @@
 #define LED				A5
 #define PAYLOAD_SIZE	NRF905_MAX_PAYLOAD
 
-nRF905 transceiver = nRF905();
+// Provide SPI bus to use (SPI, SPI1, SPI2 etc)
+nRF905 transceiver = nRF905(SPI);
 
 static volatile uint8_t packetStatus;
 
@@ -53,11 +54,7 @@ void setup()
 
 	pinMode(LED, OUTPUT);
 
-	// This must be called first
-	SPI.begin();
-
 	transceiver.begin(
-		SPI, // SPI bus to use (SPI, SPI1, SPI2 etc)
 		10000000, // SPI Clock speed (10MHz)
 		6, // SPI SS
 		7, // CE (standby)

--- a/src/nRF905.cpp
+++ b/src/nRF905.cpp
@@ -183,12 +183,7 @@ bool nRF905::addressMatched()
 	return digitalRead(am);
 }
 
-nRF905::nRF905()
-{
-}
-
 void nRF905::begin(
-	SPIClass spi,
 	uint32_t spiClock,
 	int csn,
 	int trx,
@@ -201,7 +196,8 @@ void nRF905::begin(
 	void (*callback_interrupt_am)()
 )
 {
-	this->spi = spi;
+	this->spi.begin();
+
 	this->spiSettings = SPISettings(spiClock, MSBFIRST, SPI_MODE0);
 
 	this->csn = csn;

--- a/src/nRF905.h
+++ b/src/nRF905.h
@@ -99,7 +99,7 @@ typedef enum
 class nRF905 //: public Stream // TODO see Wire library
 {
 private:
-	SPIClass spi;
+	SPIClass &spi;
 	SPISettings spiSettings;
 
 #if defined(ESP32) || defined(ESP8266)
@@ -148,7 +148,7 @@ public:
 	virtual void flush();
 	using Print::write;*/
 
-	nRF905();
+	nRF905(SPIClass& spi): spi(spi) {};
 
 /**
 * @brief Initialise, must be called after SPI.begin() and before any other nRF905 stuff
@@ -176,7 +176,6 @@ public:
 * @return (none)
 */
 	void begin(
-		SPIClass spi,
 		uint32_t spiClock,
 		int csn,
 		int trx,


### PR DESCRIPTION
Fix for the issue discussed here: https://github.com/ZakKemble/nRF905-arduino/issues/3

There are some minor additional tweaks:

- Automatic call of SPI.begin() when you call the begin() function of the library.
- All examples have been updated to apply the fix (except for the wireless serial link and callback irq examples). I tested this on both Arduino and ESP, and works fine.
- Simple explanation added to the debug sketch on how to use a different SPI bus on ESP.